### PR TITLE
djangorestframework-jsonapi 5.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ This package makes [drf-yasg Yet Another Swagger Generator](https://github.com/a
 
 ### Compatibility
 
-- Django REST Framework JSON API: `2.8`, `3.0`, `3.1`, `3.2`, `4.0`
+- Django REST Framework JSON API: `2.8`, `3.0`, `3.1`, `3.2`, `4.0`, `4.1`, `4.2`, `4.3`, `5.0`
 - Drf-yasg: `1.16`, `1.17.0`, `1.17.1`, `1.20`
 
 
-- Django REST Framework: `3.8`, `3.9`, `3.10`, `3.11`, `3.12`
-- Django: `2.0`, `2.1`, `2.2`, `3.0`, `3.1`
+- Django REST Framework: `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`
+- Django: `2.0`, `2.1`, `2.2`, `3.0`, `3.1`, `3.2`
 - Python: `3.6`, `3.7`, `3.8`, `3.9`
 
 ### Installation

--- a/drf_yasg_json_api/inspectors/field.py
+++ b/drf_yasg_json_api/inspectors/field.py
@@ -15,6 +15,7 @@ from rest_framework.serializers import BaseSerializer
 from rest_framework.settings import api_settings
 from rest_framework_json_api import serializers as dja_serializers
 from rest_framework_json_api import utils as json_api_utils
+from rest_framework_json_api.settings import json_api_settings
 from rest_framework_json_api.utils import format_value
 from rest_framework_json_api.utils import get_resource_name
 from rest_framework_json_api.utils import get_resource_type_from_model
@@ -409,7 +410,7 @@ class ManyRelatedFieldInspector(inspectors.SimpleFieldInspector):
 class NamesFormatFilter(inspectors.FieldInspector):
 
     def format_string(self, s):
-        return format_value(s)
+        return format_value(s, json_api_settings.FORMAT_FIELD_NAMES)
 
     def format_schema(self, schema):
         """Recursively format property names for the given schema according to``JSON_API_FORMAT_KEYS`` setting.

--- a/drf_yasg_json_api/inspectors/view.py
+++ b/drf_yasg_json_api/inspectors/view.py
@@ -8,6 +8,7 @@ from drf_yasg.utils import filter_none
 from drf_yasg.utils import guess_response_status
 from rest_framework import serializers
 from rest_framework.status import is_success
+from rest_framework_json_api.settings import json_api_settings
 from rest_framework_json_api.utils import format_value
 from rest_framework_json_api.utils import get_resource_type_from_serializer
 
@@ -234,4 +235,4 @@ class SwaggerAutoSchema(inspectors.SwaggerAutoSchema):
         return all_included_paths, all_included_serializers
 
     def _format_key(self, s):
-        return format_value(s)
+        return format_value(s, json_api_settings.FORMAT_FIELD_NAMES)

--- a/drf_yasg_json_api/inspectors/view.py
+++ b/drf_yasg_json_api/inspectors/view.py
@@ -9,9 +9,9 @@ from drf_yasg.utils import guess_response_status
 from rest_framework import serializers
 from rest_framework.status import is_success
 from rest_framework_json_api.utils import format_value
-from rest_framework_json_api.utils import get_included_serializers
 from rest_framework_json_api.utils import get_resource_type_from_serializer
 
+from drf_yasg_json_api.utils import get_included_serializers
 from drf_yasg_json_api.utils import is_json_api_request
 from drf_yasg_json_api.utils import is_json_api_response
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
-django>=1.11
+django>=1.11,<4.0.0
 djangorestframework>=3.7.7
 djangorestframework-jsonapi>=2.4.0
+django-filter>=2.0
 drf-yasg>=1.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ envlist =
     test-py37-django{111,20,22}-drf310-jsonapi28-yasg170
     test-py37-django{22,30}-drf311-jsonapi{31,32}-yasg171
     # yasg200 and jsonapi40 require drf312 or higher
-    test-py37-django{22,30,31}-drf312-jsonapi40-yasg200
+    test-py37-django{22,30}-drf312-jsonapi{40,43}-yasg200
+    test-py37-django32-drf312-jsonapi{42,43,50}-yasg200
+    test-py37-django32-drf313-jsonapi50-yasg200
 
     test-py38-django22-drf{38,39}-jsonapi28-yasg170
     # jsonapi30 require drf310 or higher
@@ -21,9 +23,13 @@ envlist =
     # jsonapi32 support django up to 3.0 and drf up to 311, yasg 171 added support for drf311
     test-py38-django{22,30}-drf{310,311}-jsonapi{31,32}-yasg171
     # yasg200 and jsonapi40 require drf312 or higher
-    test-py38-django{22,30,31}-drf312-jsonapi40-yasg200
+    test-py38-django{22,30}-drf312-jsonapi{40,43}-yasg200
+    test-py38-django32-drf312-jsonapi{42,43,50}-yasg200
+    test-py38-django32-drf313-jsonapi50-yasg200
 
-    test-py39-django{22,30,31}-drf312-jsonapi40-yasg200
+    test-py39-django{22,30}-drf312-jsonapi{40,43}-yasg200
+    test-py39-django32-drf312-jsonapi{42,43,50}-yasg200
+    test-py39-django32-drf313-jsonapi50-yasg200
 
 skip_missing_interpreters = true
 
@@ -37,13 +43,14 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 
     drf38: djangorestframework>=3.8,<3.9
     drf39: djangorestframework>=3.9,<3.10
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
 
     jsonapi28: djangorestframework-jsonapi>=2.8,<2.9
     jsonapi28: django-filter==2.0
@@ -51,6 +58,8 @@ deps =
     jsonapi31: djangorestframework-jsonapi[django-filter]>=3.1,<3.2
     jsonapi32: djangorestframework-jsonapi[django-filter]>=3.2,<3.3
     jsonapi40: djangorestframework-jsonapi[django-filter]>=4.0,<4.1
+    jsonapi43: djangorestframework-jsonapi[django-filter]>=4.3,<4.4
+    jsonapi50: djangorestframework-jsonapi[django-filter]>=5.0,<5.1
 
     yasg14: drf-yasg>=1.14,<1.15
     yasg15: drf-yasg>=1.15,<1.16


### PR DESCRIPTION
Closes #8 

I tried to make the changes backwards compatible. 

@glowka if you are ok with dropping support of `djangorestframework-jsonapi<5.0`, commit https://github.com/glowka/drf-yasg-json-api/commit/53dfa8f1d7e55288488165c15bd2292ecf2bc191 can be simplified a lot and avoid introduction of `get_included_serializers` function.