### PR TITLE
Check pagination class before inspecting data

### DIFF
--- a/drf_yasg_json_api/inspectors/query.py
+++ b/drf_yasg_json_api/inspectors/query.py
@@ -36,10 +36,11 @@ class DjangoFilterInspector(inspectors.CoreAPICompatInspector):
 class DjangoRestResponsePagination(inspectors.PaginatorInspector):
 
     def get_paginated_response(self, paginator, response_schema):
-        assert 'data' in response_schema['properties'], "expected data field in response"
-        assert response_schema['properties']['data'].type == openapi.TYPE_ARRAY, "array expected for paged response"
         if not isinstance(paginator, (pagination.JsonApiPageNumberPagination, pagination.JsonApiLimitOffsetPagination)):
             return inspectors.NotHandled
+
+        assert 'data' in response_schema['properties'], "expected data field in response"
+        assert response_schema['properties']['data'].type == openapi.TYPE_ARRAY, "array expected for paged response"
 
         has_page = isinstance(paginator, pagination.JsonApiPageNumberPagination)
         meta_schema = openapi.Schema(


### PR DESCRIPTION
# Description

Pagination classes other than the two json:api classes may not have the expected response schema, leading to a KeyError. Checking the pagination class before inspecting the data will correctly ignore such pagination classes rather than attempting to inspect them and failing.

# Testing

Ran `manage.py generate_swagger` on a (proprietary) project using mostly json:api endpoints and a couple other JSON endpoints.

Before:

<details><summary><code>KeyError</code> on missing field</summary>

```python
  File "/path/to/repo/project/manage.py", line 21, in <module>
    execute_from_command_line(sys.argv)
  File "/path/to/venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/path/to/venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/path/to/venv/lib/python3.9/site-packages/django/core/management/base.py", line 402, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/path/to/venv/lib/python3.9/site-packages/django/core/management/base.py", line 448, in execute
    output = self.handle(*args, **options)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/management/commands/generate_swagger.py", line 152, in handle
    schema = self.get_schema(generator, request, not private)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/management/commands/generate_swagger.py", line 110, in get_schema
    return generator.get_schema(request=request, public=public)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/generators.py", line 276, in get_schema
    paths, prefix = self.get_paths(endpoints, components, request, public)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/generators.py", line 482, in get_paths
    operation = self.get_operation(view, path, prefix, method, components, request)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/generators.py", line 524, in get_operation
    operation = view_inspector.get_operation(operation_keys)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/inspectors/view.py", line 45, in get_operation
    responses = self.get_responses()
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/inspectors/view.py", line 180, in get_responses
    response_serializers = self.get_response_serializers()
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/inspectors/view.py", line 235, in get_response_serializers
    responses = self.get_default_responses()
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg_json_api/inspectors/view.py", line 85, in get_default_responses
    return super().get_default_responses()
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/inspectors/view.py", line 217, in get_default_responses
    default_schema = self.get_paginated_response(default_schema) or default_schema
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/inspectors/base.py", line 461, in get_paginated_response
    return self.probe_inspectors(self.paginator_inspectors, 'get_paginated_response',
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg/inspectors/base.py", line 110, in probe_inspectors
    result = method(obj, **kwargs)
  File "/path/to/venv/lib/python3.9/site-packages/drf_yasg_json_api/inspectors/query.py", line 41, in get_paginated_response
    assert 'data' in response_schema['properties'], "expected data field in response"
KeyError: 'properties'
```
</details>

## After
Schema is successfully generated.